### PR TITLE
Fix EFI partition cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The program currently supports Ubuntu 18.04 (Bionic). It uses the widespread [jo
 
 EFI boot is required (any modern (2011+) system will do); legacy boot is currently not supported.
 
-RAID-1 (mirroring) is supported, with any arbitrary number of disks; both the boot and root pools are mirrored, however, the EFI partition is currently not functionally cloned.
+RAID-1 (mirroring) is supported, with any arbitrary number of disks; the boot and root pools are mirrored, and the EFI partition is cloned for each disk.
 
 It's fairly easy to extend the program to support at least other Debian-based operating systems (any Debian, older Ubuntu, etc.) - the project is (very) open to feature requests.
 

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -571,8 +571,8 @@ function clone_efi_partition {
   local selected_disk_i=2
 
   for selected_disk in "${v_selected_disks[@]:1}"; do
-    dd if="${v_selected_disks[0]}-part2" of="${selected_disk}-part2"
-    efibootmgr --create --disk "${selected_disk}" --part 2 --label "ubuntu-$selected_disk_i" --loader '\EFI\ubuntu\grubx64.efi'
+    dd if="${v_selected_disks[0]}-part1" of="${selected_disk}-part1"
+    efibootmgr --create --disk "${selected_disk}" --label "ubuntu-$selected_disk_i" --loader '\EFI\ubuntu\grubx64.efi'
     ((selected_disk_i += 1))
   done
 }


### PR DESCRIPTION
The partition cloned was the wrong one (`-part2` instead of `-part1`).

Closes #1.