### PR TITLE
Wait for availability after creating the ZFS temporary volume

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -449,6 +449,11 @@ function prepare_disks {
 function create_temp_volume {
   zfs create -V 10G "$v_rpool_name/os-install-temp"
 
+  # The volume may not be immediately available; for reference, "/dev/zvol/.../os-install-temp"
+  # is a standard file, which turns into symlink once the volume is available. See #8.
+  #
+  udevadm settle
+
   v_temp_volume_device=$(readlink -f "/dev/zvol/$v_rpool_name/os-install-temp")
 
   sgdisk -n1:0:0 -t1:8300 "$v_temp_volume_device"


### PR DESCRIPTION
In some cases, the volume is not immediately available, so we make sure that there are no pending udev events.

Closes #8.