### PR TITLE
LinuxMint fix: add required `apt update` after adding the ZFS PPA

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -730,12 +730,12 @@ ask_free_tail_space
 ask_pool_names
 ask_pool_tweaks
 
-install_zfs_module
+distro_dependent_invoke "install_zfs_module"
 prepare_disks
 
 if [[ "${ZFS_OS_INSTALLATION_SCRIPT:-}" == "" ]]; then
-  create_temp_volume
-  install_operating_system
+  distro_dependent_invoke "create_temp_volume"
+  distro_dependent_invoke "install_operating_system"
   sync_os_temp_installation_dir_to_rpool
   destroy_temp_volume
   prepare_jail

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -38,6 +38,16 @@ c_ubiquity_destination_mount=/target
 
 # HELPER FUNCTIONS #############################################################
 
+function distro_dependent_invoke {
+  local distro_specific_fx_name="$1_$v_linux_distribution"
+
+  if declare -f "$distro_specific_fx_name"; then
+    "$distro_specific_fx_name"
+  else
+    "$1"
+  fi
+}
+
 # shellcheck disable=SC2120 # allow parameters passing even if no calls pass any
 function print_step_info_header {
   echo -n "

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -507,6 +507,8 @@ function create_temp_volume {
   v_temp_volume_device=$(readlink -f "/dev/zvol/$v_rpool_name/os-install-temp")
 
   sgdisk -n1:0:0 -t1:8300 "$v_temp_volume_device"
+
+  udevadm settle
 }
 
 function install_operating_system {

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -29,7 +29,7 @@ v_temp_volume_device=        # /dev/zdN
 
 c_default_bpool_tweaks="-o ashift=12"
 c_default_rpool_tweaks="-o ashift=12 -O acltype=posixacl -O compression=lz4 -O dnodesize=auto -O relatime=on -O xattr=sa -O normalization=formD"
-c_mount_dir=/mnt
+c_zfs_mount_dir=/mnt
 declare -A c_supported_linux_distributions=([Ubuntu]=18.04 [LinuxMint]=19)
 declare -A c_linux_setups_zfs_0_8_support=([Ubuntu]=1 [LinuxMint]=1) # Avoid using the term
                              # "distribution", which is somewhat misleading in this context.
@@ -90,7 +90,7 @@ function print_variables {
 }
 
 function chroot_execute {
-  chroot $c_mount_dir bash -c "$1"
+  chroot $c_zfs_mount_dir bash -c "$1"
 }
 
 # PROCEDURE STEP FUNCTIONS #####################################################
@@ -119,11 +119,11 @@ The procedure can be entirely automated via environment variables:
 
 - ZFS_SKIP_LIVE_ZFS_MODULE_INSTALL : (debug) set 1 to skip installing the ZFS package on the live system; speeds up installation on preset machines
 
-When installing the O/S via $ZFS_OS_INSTALLATION_SCRIPT, the root pool is mounted as `'$c_mount_dir'`; the requisites are:
+When installing the O/S via $ZFS_OS_INSTALLATION_SCRIPT, the root pool is mounted as `'$c_zfs_mount_dir'`; the requisites are:
 
-1. the virtual filesystems must be mounted in `'$c_mount_dir'` (ie. `for vfs in proc sys dev; do mount --rbind /$vfs '$c_mount_dir'/$vfs; done`)
-2. internet must be accessible while chrooting in `'$c_mount_dir'` (ie. `echo nameserver 8.8.8.8 >> '$c_mount_dir'/etc/resolv.conf`)
-3. `'$c_mount_dir'` must be left in a dismountable state (e.g. no file locks, no swap etc.);
+1. the virtual filesystems must be mounted in `'$c_zfs_mount_dir'` (ie. `for vfs in proc sys dev; do mount --rbind /$vfs '$c_zfs_mount_dir'/$vfs; done`)
+2. internet must be accessible while chrooting in `'$c_zfs_mount_dir'` (ie. `echo nameserver 8.8.8.8 >> '$c_zfs_mount_dir'/etc/resolv.conf`)
+3. `'$c_zfs_mount_dir'` must be left in a dismountable state (e.g. no file locks, no swap etc.);
 '
 
   echo "$help"
@@ -473,7 +473,7 @@ function prepare_disks {
   echo -n "$v_passphrase" | zpool create \
     "${encryption_options[@]}" \
     $v_rpool_tweaks \
-    -O devices=off -O mountpoint=/ -R "$c_mount_dir" -f \
+    -O devices=off -O mountpoint=/ -R "$c_zfs_mount_dir" -f \
     "$v_rpool_name" $pools_mirror_option "${rpool_disks_partitions[@]}"
 
   # `-d` disable all the pool features (not used here);
@@ -481,7 +481,7 @@ function prepare_disks {
   # shellcheck disable=SC2086 # see previous command
   zpool create \
     $v_bpool_tweaks \
-    -O devices=off -O mountpoint=/boot -R "$c_mount_dir" -f \
+    -O devices=off -O mountpoint=/boot -R "$c_zfs_mount_dir" -f \
     "$v_bpool_name" $pools_mirror_option "${bpool_disks_partitions[@]}"
 
   # SWAP ###############################
@@ -552,7 +552,7 @@ function sync_os_temp_installation_dir_to_rpool {
   # There isn't an exact way to filter out filenames in the rsync output, so we just use a good enough heuristic.
   # ❤️ Perl ❤️
   #
-  rsync -avX --exclude=/swapfile --info=progress2 --no-inc-recursive --human-readable "$c_ubiquity_destination_mount/" "$c_mount_dir" |
+  rsync -avX --exclude=/swapfile --info=progress2 --no-inc-recursive --human-readable "$c_ubiquity_destination_mount/" "$c_zfs_mount_dir" |
     perl -lane 'BEGIN { $/ = "\r"; $|++ } $F[1] =~ /(\d+)%$/ && print $1' |
     whiptail --gauge "Syncing the installed O/S to the root pool FS..." 30 100 0
 
@@ -567,7 +567,7 @@ function prepare_jail {
   print_step_info_header
 
   for virtual_fs_dir in proc sys dev; do
-    mount --rbind "/$virtual_fs_dir" "$c_mount_dir/$virtual_fs_dir"
+    mount --rbind "/$virtual_fs_dir" "$c_zfs_mount_dir/$virtual_fs_dir"
   done
 
   chroot_execute 'echo "nameserver 8.8.8.8" >> /etc/resolv.conf'
@@ -670,7 +670,7 @@ function prepare_for_system_exit {
   print_step_info_header
 
   for virtual_fs_dir in dev sys proc; do
-    umount --recursive --force --lazy "$c_mount_dir/$virtual_fs_dir"
+    umount --recursive --force --lazy "$c_zfs_mount_dir/$virtual_fs_dir"
   done
 
   # In one case, a second unmount was required. In this contenxt, bind mounts are not safe, so,
@@ -682,7 +682,7 @@ function prepare_for_system_exit {
   SECONDS=0
 
   for virtual_fs_dir in dev sys proc; do
-    while mountpoint -q "$c_mount_dir/$virtual_fs_dir" && [[ $SECONDS -lt $max_unmount_wait ]]; do
+    while mountpoint -q "$c_zfs_mount_dir/$virtual_fs_dir" && [[ $SECONDS -lt $max_unmount_wait ]]; do
       sleep 0.5
       echo -n .
     done
@@ -691,9 +691,9 @@ function prepare_for_system_exit {
   echo
 
   for virtual_fs_dir in dev sys proc; do
-    if mountpoint -q "$c_mount_dir/$virtual_fs_dir"; then
-      echo "Re-issuing umount for $c_mount_dir/$virtual_fs_dir"
-      umount --recursive --force --lazy "$c_mount_dir/$virtual_fs_dir"
+    if mountpoint -q "$c_zfs_mount_dir/$virtual_fs_dir"; then
+      echo "Re-issuing umount for $c_zfs_mount_dir/$virtual_fs_dir"
+      umount --recursive --force --lazy "$c_zfs_mount_dir/$virtual_fs_dir"
     fi
   done
 

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -752,5 +752,9 @@ clone_efi_partition
 configure_boot_pool_import
 configure_remaining_settings
 
+# DEBUG
+echo "Press enter to proceed to the chrooted env dismount..."
+read -rsn1
+
 prepare_for_system_exit
 display_exit_banner

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -30,11 +30,11 @@ v_temp_volume_device=        # /dev/zdN
 c_default_bpool_tweaks="-o ashift=12"
 c_default_rpool_tweaks="-o ashift=12 -O acltype=posixacl -O compression=lz4 -O dnodesize=auto -O relatime=on -O xattr=sa -O normalization=formD"
 c_zfs_mount_dir=/mnt
+c_installed_os_data_mount_dir=/target
 declare -A c_supported_linux_distributions=([Ubuntu]=18.04 [LinuxMint]=19)
 declare -A c_linux_setups_zfs_0_8_support=([Ubuntu]=1 [LinuxMint]=1) # Avoid using the term
                              # "distribution", which is somewhat misleading in this context.
 c_temporary_volume_size=12G  # large enough; Debian, for example, takes ~8 GiB.
-c_ubiquity_destination_mount=/target
 
 # HELPER FUNCTIONS #############################################################
 
@@ -542,8 +542,8 @@ Proceed with the configuration as usual, then, at the partitioning stage:
   #
   # Note that we assume that the user created only one partition on the temp volume, as expected.
   #
-  if ! mountpoint -q "$c_ubiquity_destination_mount"; then
-    mount "${v_temp_volume_device}p1" "$c_ubiquity_destination_mount"
+  if ! mountpoint -q "$c_installed_os_data_mount_dir"; then
+    mount "${v_temp_volume_device}p1" "$c_installed_os_data_mount_dir"
   fi
 }
 
@@ -552,11 +552,11 @@ function sync_os_temp_installation_dir_to_rpool {
   # There isn't an exact way to filter out filenames in the rsync output, so we just use a good enough heuristic.
   # ❤️ Perl ❤️
   #
-  rsync -avX --exclude=/swapfile --info=progress2 --no-inc-recursive --human-readable "$c_ubiquity_destination_mount/" "$c_zfs_mount_dir" |
+  rsync -avX --exclude=/swapfile --info=progress2 --no-inc-recursive --human-readable "$c_installed_os_data_mount_dir/" "$c_zfs_mount_dir" |
     perl -lane 'BEGIN { $/ = "\r"; $|++ } $F[1] =~ /(\d+)%$/ && print $1' |
     whiptail --gauge "Syncing the installed O/S to the root pool FS..." 30 100 0
 
-  umount "$c_ubiquity_destination_mount"
+  umount "$c_installed_os_data_mount_dir"
 }
 
 function destroy_temp_volume {

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -371,18 +371,16 @@ function ask_pool_tweaks {
 function install_host_zfs_module {
   print_step_info_header
 
-  if [[ "${c_linux_setups_zfs_0_8_support["$v_linux_distribution"]}" == "1" ]]; then
-    if [[ ${ZFS_SKIP_LIVE_ZFS_MODULE_INSTALL:-} == "" ]]; then
-      echo "zfs-dkms zfs-dkms/note-incompatible-licenses note true" | debconf-set-selections
+  if [[ ${ZFS_SKIP_LIVE_ZFS_MODULE_INSTALL:-} == "" ]]; then
+    echo "zfs-dkms zfs-dkms/note-incompatible-licenses note true" | debconf-set-selections
 
-      add-apt-repository --yes ppa:jonathonf/zfs
-      apt install --yes zfs-dkms
+    add-apt-repository --yes ppa:jonathonf/zfs
+    apt install --yes zfs-dkms
 
-      systemctl stop zfs-zed
-      modprobe -r zfs
-      modprobe zfs
-      systemctl start zfs-zed
-    fi
+    systemctl stop zfs-zed
+    modprobe -r zfs
+    modprobe zfs
+    systemctl start zfs-zed
   fi
 }
 
@@ -636,11 +634,7 @@ function custom_install_operating_system {
 function install_jail_zfs_packages {
   print_step_info_header
 
-  if [[ "${c_linux_setups_zfs_0_8_support["$v_linux_distribution"]}" == "1" ]]; then
-    chroot_execute "add-apt-repository --yes ppa:jonathonf/zfs"
-  else
-    chroot_execute "apt update"
-  fi
+  chroot_execute "add-apt-repository --yes ppa:jonathonf/zfs"
 
   chroot_execute 'echo "zfs-dkms zfs-dkms/note-incompatible-licenses note true" | debconf-set-selections'
   chroot_execute "apt install --yes zfs-initramfs zfs-dkms grub-efi-amd64-signed shim-signed"

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -24,8 +24,9 @@ v_rpool_tweaks=              # see defaults below for format
 declare -a v_selected_disks  # (/dev/by-id/disk_id, ...)
 v_swap_size=                 # integer
 v_free_tail_space=           # integer
-declare -a v_system_disks    # (/dev/by-id/disk_id, ...)
 v_temp_volume_device=        # /dev/zdN
+
+declare -a v_system_disks    # (/dev/by-id/disk_id, ...) - temporary (find_disks -> select_disks
 
 c_default_bpool_tweaks="-o ashift=12"
 c_default_rpool_tweaks="-o ashift=12 -O acltype=posixacl -O compression=lz4 -O dnodesize=auto -O relatime=on -O xattr=sa -O normalization=formD"

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -360,16 +360,18 @@ function ask_pool_tweaks {
 function install_zfs_module {
   print_step_info_header
 
-  if [[ ${ZFS_SKIP_LIVE_ZFS_MODULE_INSTALL:-} == "" ]]; then
-    echo "zfs-dkms zfs-dkms/note-incompatible-licenses note true" | debconf-set-selections
+  if [[ "${c_linux_setups_zfs_0_8_support["$v_linux_distribution"]}" == "1" ]]; then
+    if [[ ${ZFS_SKIP_LIVE_ZFS_MODULE_INSTALL:-} == "" ]]; then
+      echo "zfs-dkms zfs-dkms/note-incompatible-licenses note true" | debconf-set-selections
 
-    add-apt-repository --yes ppa:jonathonf/zfs
-    apt install --yes zfs-dkms
+      add-apt-repository --yes ppa:jonathonf/zfs
+      apt install --yes zfs-dkms
 
-    systemctl stop zfs-zed
-    modprobe -r zfs
-    modprobe zfs
-    systemctl start zfs-zed
+      systemctl stop zfs-zed
+      modprobe -r zfs
+      modprobe zfs
+      systemctl start zfs-zed
+    fi
   fi
 }
 
@@ -568,7 +570,12 @@ function custom_install_operating_system {
 function install_zfs_0.8_packages {
   print_step_info_header
 
-  chroot_execute "add-apt-repository --yes ppa:jonathonf/zfs"
+  if [[ "${c_linux_setups_zfs_0_8_support["$v_linux_distribution"]}" == "1" ]]; then
+    chroot_execute "add-apt-repository --yes ppa:jonathonf/zfs"
+  else
+    chroot_execute "apt update"
+  fi
+
   chroot_execute 'echo "zfs-dkms zfs-dkms/note-incompatible-licenses note true" | debconf-set-selections'
   chroot_execute "apt install --yes zfs-initramfs zfs-dkms grub-efi-amd64-signed shim-signed"
 }

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -368,7 +368,7 @@ function ask_pool_tweaks {
   print_variables v_bpool_tweaks v_rpool_tweaks
 }
 
-function install_zfs_module {
+function install_host_zfs_module {
   print_step_info_header
 
   if [[ "${c_linux_setups_zfs_0_8_support["$v_linux_distribution"]}" == "1" ]]; then
@@ -580,7 +580,7 @@ function custom_install_operating_system {
   sudo "$ZFS_OS_INSTALLATION_SCRIPT"
 }
 
-function install_zfs_0.8_packages {
+function install_jail_zfs_packages {
   print_step_info_header
 
   if [[ "${c_linux_setups_zfs_0_8_support["$v_linux_distribution"]}" == "1" ]]; then
@@ -733,7 +733,7 @@ ask_free_tail_space
 ask_pool_names
 ask_pool_tweaks
 
-distro_dependent_invoke "install_zfs_module"
+distro_dependent_invoke "install_host_zfs_module"
 prepare_disks
 
 if [[ "${ZFS_OS_INSTALLATION_SCRIPT:-}" == "" ]]; then
@@ -746,7 +746,7 @@ else
   custom_install_operating_system
 fi
 
-install_zfs_0.8_packages
+install_jail_zfs_packages
 install_and_configure_bootloader
 clone_efi_partition
 configure_boot_pool_import

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -375,6 +375,13 @@ function install_host_zfs_module {
     echo "zfs-dkms zfs-dkms/note-incompatible-licenses note true" | debconf-set-selections
 
     add-apt-repository --yes ppa:jonathonf/zfs
+
+    # Required only on LinuxMint, which doesn't update the apt data when invoking `add-apt-repository`.
+    # With the current design, it's arguably preferrable to introduce a redundant operation (for
+    # Ubuntu), rather than adding an almost entirely duplicated function.
+    #
+    apt update
+
     apt install --yes zfs-dkms
 
     systemctl stop zfs-zed
@@ -635,6 +642,10 @@ function install_jail_zfs_packages {
   print_step_info_header
 
   chroot_execute "add-apt-repository --yes ppa:jonathonf/zfs"
+
+  # See install_host_zfs_module() comment.
+  #
+  chroot_execute "apt update"
 
   chroot_execute 'echo "zfs-dkms zfs-dkms/note-incompatible-licenses note true" | debconf-set-selections'
   chroot_execute "apt install --yes zfs-initramfs zfs-dkms grub-efi-amd64-signed shim-signed"


### PR DESCRIPTION
On LinuxMint, `add-apt-repository` doesn't update the apt data.

The solution is arguable, but with the current design, the alternative isn't absolutely better.