### PR TITLE
Fix Subiquity issue with stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ then follow the instructions; halfway through the procedure, the GUI installer o
 Ubuntu Server requires a slightly different execution procedure:
 
 - when the installer welcome screen shows up, tap `Ctrl+Alt+F2`,
-- then type `curl -L https://git.io/JelI5 | sudo bash -`.
+- then type `sudo -- bash -c "$(curl -L https://git.io/JelI5)"`.
 
 the rest is the same as the generic procedure.
 


### PR DESCRIPTION
When piping the script to bash, Subiquity will raise an error on execution. Sample, with direct invocation:

```
echo 'PATH="/snap/subiquity/1093/bin:/snap/subiquity/1093/usr/bin:$PATH" snap run subiquity' | sudo bash -
Traceback (most recent call last):
  File "/snap/subiquity/1093/usr/lib/python3/dist-packages/urwid/raw_display.py", line 554, in _getch
    return ord(os.read(self._term_input_file.fileno(), 1))
TypeError: ord() expected a character, but string of length 0 found
```

It's not clear how Subiquity uses stdin, however, it's more solid design to make it available.

The solution is to run the script as a bash `-c` parameter; since this makes the invocation more complex, it's currently used only for Ubuntu Server.

Closes #41.