### PR TITLE
Fix for pools not being imported onto reboot

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -1042,7 +1042,9 @@ Before=zfs-import-cache.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+ExecStartPre=/bin/sh -c '[ -f /etc/zfs/zpool.cache ] && mv /etc/zfs/zpool.cache /etc/zfs/preboot_zpool.cache || true'
 ExecStart=/sbin/zpool import -N -o cachefile=none $v_bpool_name
+ExecStartPost=/bin/sh -c '[ -f /etc/zfs/preboot_zpool.cache ] && mv /etc/zfs/preboot_zpool.cache /etc/zfs/zpool.cache || true'
 
 [Install]
 WantedBy=zfs-import.target


### PR DESCRIPTION
This is a fix for bpool import service, causing cachefile being correctly preserved upon machine reboot. Without it, any imported zfs pools, stored before reboot inside /etc/zfs/zpool.cache are ignored.
See [my comment](https://github.com/zfsonlinux/zfs/issues/8549#issuecomment-569120693) on the defect 8549 for more details how I've discovered this bug.