### PR TITLE
Fix disk devices sometimes being filtered out

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -188,7 +188,7 @@ function store_os_distro_information {
 function set_distribution_data {
   v_linux_distribution="$(lsb_release --id --short)"
 
-  if [[ "$v_linux_distribution" == "Ubuntu" ]] && dpkg -s ubuntu-server 2> /dev/null | grep -q '^Status: install ok installed$'; then
+  if [[ "$v_linux_distribution" == "Ubuntu" ]] && grep -q '^Status: install ok installed$' < <(dpkg -s ubuntu-server 2> /dev/null); then
     v_linux_distribution="UbuntuServer"
   fi
 
@@ -269,7 +269,7 @@ function find_suitable_disks {
     # Therefore, it's probably best to rely on the id name, and just filter out optical devices.
     #
     if ! grep -q '^ID_TYPE=cd$' <<< "$device_info"; then
-      if ! echo "$mounted_devices" | grep -q "^$block_device_basename\$"; then
+      if ! grep -q "^$block_device_basename\$" <<< "$mounted_devices"; then
         v_suitable_disks+=("$disk_id")
       fi
     fi


### PR DESCRIPTION
The `udevadm` output seems not to be sufficient, so we relax the conditions (see comment).

Closes #48.