### PR TITLE
Debian updates: fixes, but also officially remove the Debian support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The program currently supports:
 
 - Ubuntu Desktop/Server 18.04.x Live
 - Linux Mint 19.x
-- Debian 10.1 Live (desktop environment required)
+- ~~Debian 10.1 Live (desktop environment required)~~ (currently has an [issue](https://github.com/saveriomiroddi/zfs-installer/issues/56))
 - ElementaryOS 5.1
 
 The ZFS version installed is 0.8, which supports native encryption and trimming (among the other improvements over 0.7). The required repositories are automatically added to the destination system.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The program currently supports:
 
 - Ubuntu Desktop/Server 18.04.x Live
 - Linux Mint 19.x
-- Debian 10.1
+- Debian 10.1 Live (desktop environment required)
 - ElementaryOS 5.1
 
 The ZFS version installed is 0.8, which supports native encryption and trimming (among the other improvements over 0.7). The required repositories are automatically added to the destination system.

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -754,7 +754,12 @@ Proceed with the configuration as usual, then, at the partitioning stage:
     whiptail --msgbox "$dialog_message" 30 100
   fi
 
-  calamares
+  # The display is restricted only to the owner (`user`), so we need to allow any user to access
+  # it.
+  #
+  sudo -u "$SUDO_USER" env DISPLAY=:0 xhost +
+
+  DISPLAY=:0 calamares
 
   mkdir -p "$c_installed_os_data_mount_dir"
 

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -1071,7 +1071,12 @@ function update_zed_cache_Debian {
 
   chroot_execute "zed -F &"
   chroot_execute "[[ ! -s /etc/zfs/zfs-list.cache/$v_rpool_name ]] && zfs set canmount=noauto $v_rpool_name || true"
-  chroot_execute "[[ ! -s /etc/zfs/zfs-list.cache/$v_rpool_name ]] && false"
+
+  if chroot /mnt bash -c "[[ ! -s /etc/zfs/zfs-list.cache/$v_rpool_name ]]"; then
+    echo "Error: The ZFS cache hasn't been updated by ZED!"
+    exit 1
+  fi
+
   chroot_execute "pkill zed"
 
   chroot_execute "sed -Ei 's|$c_installed_os_data_mount_dir/?|/|' /etc/zfs/zfs-list.cache/$v_rpool_name"

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -1075,7 +1075,7 @@ function update_zed_cache_Debian {
   chroot_execute "ln -s /usr/lib/zfs-linux/zed.d/history_event-zfs-list-cacher.sh /etc/zfs/zed.d/"
 
   chroot_execute "zed -F &"
-  chroot_execute "[[ ! -s /etc/zfs/zfs-list.cache/$v_rpool_name ]] && zfs set canmount=noauto $v_rpool_name || true"
+  chroot_execute "if [[ ! -s /etc/zfs/zfs-list.cache/$v_rpool_name ]]; then zfs set canmount=noauto $v_rpool_name; fi"
 
   if chroot /mnt bash -c "[[ ! -s /etc/zfs/zfs-list.cache/$v_rpool_name ]]"; then
     echo "Error: The ZFS cache hasn't been updated by ZED!"

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -763,7 +763,10 @@ Proceed with the configuration as usual, then, at the partitioning stage:
   #
   mount "${v_temp_volume_device}" "$c_installed_os_data_mount_dir"
 
-  chroot_execute "echo root:$(printf "%q" "$v_root_password") | chpasswd"
+  # We don't use chroot()_execute here, as it works on $c_zfs_mount_dir (which is synced on a
+  # later stage).
+  #
+  chroot "$c_installed_os_data_mount_dir" bash -c "echo root:$(printf "%q" "$v_root_password") | chpasswd"
 
   # The installer doesn't set the network interfaces, so, for convenience, we do it.
   #


### PR DESCRIPTION
Several fixes (not clear how the installation could possibly work before), but at the same time, removed the Debian support, blocked by https://github.com/saveriomiroddi/zfs-installer/issues/56.