### PR TITLE
Debian: Workaround issue with ZFS cache not updated

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -1074,6 +1074,11 @@ function update_zed_cache_Debian {
   chroot_execute "touch /etc/zfs/zfs-list.cache/$v_rpool_name"
   chroot_execute "ln -s /usr/lib/zfs-linux/zed.d/history_event-zfs-list-cacher.sh /etc/zfs/zed.d/"
 
+  # Assumed to be present by the zedlet above, but missing.
+  # Filed issue: https://github.com/zfsonlinux/zfs/issues/9945.
+  #
+  chroot_execute "mkdir /run/lock"
+
   chroot_execute "zed -F &"
   chroot_execute "if [[ ! -s /etc/zfs/zfs-list.cache/$v_rpool_name ]]; then zfs set canmount=noauto $v_rpool_name; fi"
 


### PR DESCRIPTION
The zedlet assumes a directory that doesn't exist (`/run/lock`).

See issue: https://github.com/zfsonlinux/zfs/issues/9945.

Closes #56.