### PR TITLE
Fix Ubuntu 18.04.4 display-related issues

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -731,7 +731,7 @@ Proceed with the configuration as usual, then, at the partitioning stage:
     whiptail --msgbox "$dialog_message" 30 100
   fi
 
-  ubiquity --no-bootloader
+  DISPLAY=:0 ubiquity --no-bootloader
 
   swapoff -a
 

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -731,6 +731,11 @@ Proceed with the configuration as usual, then, at the partitioning stage:
     whiptail --msgbox "$dialog_message" 30 100
   fi
 
+  # The display is restricted only to the owner (`user`), so we need to allow any user to access
+  # it.
+  #
+  sudo -u "$SUDO_USER" env DISPLAY=:0 xhost +
+
   DISPLAY=:0 ubiquity --no-bootloader
 
   swapoff -a
@@ -767,8 +772,7 @@ Proceed with the configuration as usual, then, at the partitioning stage:
     whiptail --msgbox "$dialog_message" 30 100
   fi
 
-  # The display is restricted only to the owner (`user`), so we need to allow any user to access
-  # it.
+  # See install_operating_system().
   #
   sudo -u "$SUDO_USER" env DISPLAY=:0 xhost +
 


### PR DESCRIPTION
Ubuntu (MATE) 18.04.4 required the same display-related settings in order to run the installer from a terminal/SSH.

Closes #66.