### PR TITLE
Compatibility with Ubuntu Server 18.04.4 Live installer

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -846,13 +846,17 @@ DIFF
 
   patch -p1 "$c_unpacked_subiquity_dir/lib/python3.6/site-packages/subiquity/ui/views/installprogress.py" << 'DIFF'
 diff lib/python3.6/site-packages/subiquity/ui/views/installprogress.py{.bak,}
-122,125c122
-<         if include_exit:
-<             btns = [self.view_log_btn, self.exit_btn, self.reboot_btn]
-<         else:
-<             btns = [self.view_log_btn, self.reboot_btn]
+47a48,49
+>         self.exit_btn = cancel_btn(
+>             _("Exit To Shell"), on_press=self.quit)
+121c123
+<         btns = [self.view_log_btn, self.reboot_btn]
 ---
 >         btns = [self.view_log_btn, self.exit_btn, self.reboot_btn]
+133a136,138
+>     def quit(self, btn):
+>         self.controller.quit()
+> 
 DIFF
 
   snap stop subiquity


### PR DESCRIPTION
`subiquity/ui/views/installprogress.py` changed in 18.04.4, so that applying the patch for that file fails - and the entire installation along with it.

This PR restores `Exit To Shell` in `subiquity/ui/views/installprogress.py` and patches the file to again provide that option, so that the `zfs-installer` can resume work after installation.

I just installed a new instance of Ubuntu Server 18.04.4 using the live installer and my adapted version of the script and it worked without any issues.

If anyone else wants to install Ubuntu Server 18.04.4 with the live installer in the meantime - this line uses my script version:
`sudo -- bash -c "$(curl -L https://git.io/JvKqK)"`


Thanks for your work Saverio!