### PR TITLE
Fixed Debian install and added raidz support

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -991,7 +991,7 @@ APT'
   chroot_execute "apt update"
 
   chroot_execute 'echo "zfs-dkms zfs-dkms/note-incompatible-licenses note true" | debconf-set-selections'
-  chroot_execute "apt install --yes rsync zfs-initramfs zfs-dkms grub-efi-amd64-signed shim-signed"
+  chroot_execute "apt install --yes rsync efibootmgr zfs-initramfs zfs-dkms grub-efi-amd64-signed shim-signed"
 }
 
 function install_jail_zfs_packages_elementary {

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -991,7 +991,7 @@ APT'
   chroot_execute "apt update"
 
   chroot_execute 'echo "zfs-dkms zfs-dkms/note-incompatible-licenses note true" | debconf-set-selections'
-  chroot_execute "apt install --yes zfs-initramfs zfs-dkms grub-efi-amd64-signed shim-signed"
+  chroot_execute "apt install --yes rsync zfs-initramfs zfs-dkms grub-efi-amd64-signed shim-signed"
 }
 
 function install_jail_zfs_packages_elementary {

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -763,7 +763,7 @@ function install_operating_system_Debian {
 Proceed with the configuration as usual, then, at the partitioning stage:
 
 - check `Manual partitioning` -> `Next`
-- set `Storage device` to `Unknown - 10.0 GB '"${v_temp_volume_device}"'`
+- set `Storage device` to `Unknown - 12.0 GB '"${v_temp_volume_device}"'`
 - click on `'"${v_temp_volume_device}"'` in the filesystems panel -> `Edit`
   - set `Mount Point` to `/` -> `OK`
 - `Next`

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -332,7 +332,7 @@ function select_disks {
         menu_entries_option+=("$disk_id" "($block_device_basename)" "$disk_selection_status")
       done
 
-      local dialog_message="Select the ZFS devices (multiple selections will be in mirror).
+      local dialog_message="Select the ZFS devices (couple devices would create a mirror, more than two selections will be in raidz).
 
 Devices with mounted partitions, cdroms, and removable devices are not displayed!
 "
@@ -629,10 +629,12 @@ function prepare_disks {
     bpool_disks_partitions+=("${selected_disk}-part2")
   done
 
-  if [[ ${#v_selected_disks[@]} -gt 1 ]]; then
-    local pools_mirror_option=mirror
+  if [[ ${#v_selected_disks[@]} -gt 2 ]]; then
+    local pools_raid_option=raidz
+  elif [[ ${#v_selected_disks[@]} -eq 2 ]]; then
+    local pools_raid_option=mirror
   else
-    local pools_mirror_option=
+    local pools_raid_option=
   fi
 
   # POOLS CREATION #####################
@@ -650,7 +652,7 @@ function prepare_disks {
     "${encryption_options[@]}" \
     $v_rpool_tweaks \
     -O devices=off -O mountpoint=/ -R "$c_zfs_mount_dir" -f \
-    "$v_rpool_name" $pools_mirror_option "${rpool_disks_partitions[@]}"
+    "$v_rpool_name" $pools_raid_option "${rpool_disks_partitions[@]}"
 
   # `-d` disable all the pool features (not used here);
   #
@@ -658,7 +660,7 @@ function prepare_disks {
   zpool create \
     $v_bpool_tweaks \
     -O devices=off -O mountpoint=/boot -R "$c_zfs_mount_dir" -f \
-    "$v_bpool_name" $pools_mirror_option "${bpool_disks_partitions[@]}"
+    "$v_bpool_name" $pools_raid_option "${bpool_disks_partitions[@]}"
 
   # SWAP ###############################
 

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -332,7 +332,7 @@ function select_disks {
         menu_entries_option+=("$disk_id" "($block_device_basename)" "$disk_selection_status")
       done
 
-      local dialog_message="Select the ZFS devices (couple devices would create a mirror, more than two selections will be in raidz).
+      local dialog_message="Select the ZFS devices (couple devices would create mirror pools, more than two selections will create mirror for small bpool and raidz for main rpool).
 
 Devices with mounted partitions, cdroms, and removable devices are not displayed!
 "
@@ -630,11 +630,14 @@ function prepare_disks {
   done
 
   if [[ ${#v_selected_disks[@]} -gt 2 ]]; then
-    local pools_raid_option=raidz
+    local rpool_raid_option=raidz
+    local bpool_raid_option=mirror
   elif [[ ${#v_selected_disks[@]} -eq 2 ]]; then
-    local pools_raid_option=mirror
+    local rpool_raid_option=mirror
+    local bpool_raid_option=mirror
   else
-    local pools_raid_option=
+    local rpool_raid_option=
+    local bpool_raid_option=
   fi
 
   # POOLS CREATION #####################
@@ -652,7 +655,7 @@ function prepare_disks {
     "${encryption_options[@]}" \
     $v_rpool_tweaks \
     -O devices=off -O mountpoint=/ -R "$c_zfs_mount_dir" -f \
-    "$v_rpool_name" $pools_raid_option "${rpool_disks_partitions[@]}"
+    "$v_rpool_name" $rpool_raid_option "${rpool_disks_partitions[@]}"
 
   # `-d` disable all the pool features (not used here);
   #
@@ -660,7 +663,7 @@ function prepare_disks {
   zpool create \
     $v_bpool_tweaks \
     -O devices=off -O mountpoint=/boot -R "$c_zfs_mount_dir" -f \
-    "$v_bpool_name" $pools_raid_option "${bpool_disks_partitions[@]}"
+    "$v_bpool_name" $bpool_raid_option "${bpool_disks_partitions[@]}"
 
   # SWAP ###############################
 

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -518,7 +518,7 @@ function install_host_packages_Debian {
     echo "deb http://deb.debian.org/debian buster-backports main contrib" >> /etc/apt/sources.list
     apt update
 
-    apt install --yes -t buster-backports zfs-dkms
+    apt install --yes -t buster-backports zfs-dkms efibootmgr
 
     modprobe zfs
   fi
@@ -991,7 +991,7 @@ APT'
   chroot_execute "apt update"
 
   chroot_execute 'echo "zfs-dkms zfs-dkms/note-incompatible-licenses note true" | debconf-set-selections'
-  chroot_execute "apt install --yes rsync efibootmgr zfs-initramfs zfs-dkms grub-efi-amd64-signed shim-signed"
+  chroot_execute "apt install --yes rsync zfs-initramfs zfs-dkms grub-efi-amd64-signed shim-signed"
 }
 
 function install_jail_zfs_packages_elementary {


### PR DESCRIPTION
Fixed missing packets in Debian 10 installation (rsync, efibootmgr)
Fixed wrong number in on-screen manual
Feature: 3+ HDDs are using raidz pool instead of mirror pool, but bpool is always mirrored on multiple HDDs.