### PR TITLE
Improve encryption passphrase UX (and simplify logic)

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -234,6 +234,9 @@ function check_prerequisites {
   elif [[ "${ZFS_OS_INSTALLATION_SCRIPT:-}" != "" && ! -x "$ZFS_OS_INSTALLATION_SCRIPT" ]]; then
     echo "The custom O/S installation script provided doesn't exist or is not executable!"
     exit 1
+  elif [[ -v ZFS_PASSPHRASE && ${#ZFS_PASSPHRASE} -lt 8 ]]; then
+    echo "The passphase provided is too short; at least 8 chars required."
+    exit 1
   elif [[ ! -v c_supported_linux_distributions["$v_linux_distribution"] ]]; then
     echo "This Linux distribution ($v_linux_distribution) is not supported!"
     exit 1


### PR DESCRIPTION
The UX has been simplified by implying that the encryption is disabled if the user inputs an empty password (so that there's no need for a screen asking for enablement).

The code follows the same logic, relying on the `ZFS_PASSPHRASE` variable being set or not. This is a different behavior from the other variables, for which blank and unset is the same.

Closes #90.