### PR TITLE
New installation partition workflow: create/sync the pools after installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,6 @@ the rest is the same as the generic procedure.
 
 ### Issues/unsupported systems
 
-As of Feb/2020, Debian 10.x does not install stably on Virtualbox 6.x (but works fine on VMWare 15.5).  
-For unclear reasons, the EFI partition is not recognized unless the live CD is left in the virtual reader when rebooting after the installation (!).
-
 The Ubuntu Server alternate (non-live) version is not supported, as it's based on the Busybox environment, which lacks several tools used in the installer (apt, rsync...).
 
 ### Unattended installations

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ the rest is the same as the generic procedure.
 
 ### Issues/unsupported systems
 
+Due to a current problem with the zpool expansion, 12 GiB of empty space are left at the end of each disk.
+
 The Ubuntu Server alternate (non-live) version is not supported, as it's based on the Busybox environment, which lacks several tools used in the installer (apt, rsync...).
 
 ### Unattended installations


### PR DESCRIPTION
New installation partition workflow: create/sync the pools after installation

This is a significant change, in particular, it:

- solves the Ubuntu Server installation, replacing the current hacky solution;
- solves the Ubuntu Desktop 20.04 ZFS shenanigans.

There is still a pending issue - the zpool expansion doesn't work, so, it leaves 12 GiB unused, but considering the target hardware, it's a minor problem.
