### PR TITLE
Raidz instead of mirror for 3+ drives

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -414,7 +414,9 @@ function select_disks {
         menu_entries_option+=("$disk_id" "($block_device_basename)" "$disk_selection_status")
       done
 
-      local dialog_message="Select the ZFS devices (multiple selections will be in mirror).
+      local dialog_message="Select the ZFS devices.
+
+In the boot pool, multiple selections will be in mirror; in the root pool, 2 devices will be in mirror, 3 or more in RAIDZ.
 
 Devices with mounted partitions, cdroms, and removable devices are not displayed!
 "
@@ -879,10 +881,15 @@ function create_pools {
     bpool_disks_partitions+=("${selected_disk}-part2")
   done
 
-  if [[ ${#v_selected_disks[@]} -gt 1 ]]; then
-    local pools_mirror_option=mirror
+  if [[ ${#v_selected_disks[@]} -gt 2 ]]; then
+    local rpool_raid_option=raidz
+    local bpool_raid_option=mirror
+  elif [[ ${#v_selected_disks[@]} -eq 2 ]]; then
+    local rpool_raid_option=mirror
+    local bpool_raid_option=mirror
   else
-    local pools_mirror_option=
+    local rpool_raid_option=
+    local bpool_raid_option=
   fi
 
   # POOLS CREATION #####################
@@ -899,14 +906,14 @@ function create_pools {
     "${encryption_options[@]}" \
     "${v_rpool_tweaks[@]}" \
     -O devices=off -O mountpoint=/ -R "$c_zfs_mount_dir" -f \
-    "$v_rpool_name" $pools_mirror_option "${rpool_disks_partitions[@]}"
+    "$v_rpool_name" $rpool_raid_option "${rpool_disks_partitions[@]}"
 
   # `-d` disable all the pool features (not used here);
   #
   zpool create \
     "${v_bpool_tweaks[@]}" \
     -O devices=off -O mountpoint=/boot -R "$c_zfs_mount_dir" -f \
-    "$v_bpool_name" $pools_mirror_option "${bpool_disks_partitions[@]}"
+    "$v_bpool_name" $bpool_raid_option "${bpool_disks_partitions[@]}"
 }
 
 function create_swap_volume {


### PR DESCRIPTION
(Contribution by @Zapunidi, with rebase and cosmetic improvement to the message)

Previously in the script all multiple drives created a mirror. For systems will multiple 3+ drives the intended purpose is a compromise between space and redundancy.
I changed the behaviour from always mirror to mirror bpool on all drives and raidz for rpool if there are 3 or more drives.
There are drawbacks that people with 4-5+ drives may want either raidz, raidz2 or raidz3. It would be nice to allow user to select the redundancy level, but that was beyond my bash skills.
I chose to mirror bpool on all drives thus wasting boot partition space because of two reasons. First, boot is a priority and wasting a little space knowing that either drive will allow boot worth it. Second, I made tests with raidz on bpool: removing the drives one by one, checking boot, restoring drive, resilvering and so on. For reasons unknown I ended with a system that can boot from 2/3 drives, but not from 3/3. On all drives I just got grub very basic console. On the mirrored bpool I succesfully finished that test.