### PR TITLE
Install extra host package `efibootmgr` [on Ubuntu Desktop]

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -579,7 +579,7 @@ function install_host_packages {
       # Module compilation log: `/var/lib/dkms/zfs/0.8.2/build/make.log` (adjust according to version).
       #
       echo "zfs-dkms zfs-dkms/note-incompatible-licenses note true" | debconf-set-selections
-      apt install --yes libelf-dev zfs-dkms
+      apt install --yes libelf-dev zfs-dkms efibootmgr
 
       systemctl stop zfs-zed
       modprobe -r zfs


### PR DESCRIPTION
It's not clear why, but the latest installation attempt failed. Possibly, this is due to the type of installation (minimal, etc.) provided during Ubiquity.