### PR TITLE
New workflow for custom OS installation scripts, with sample

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -1356,14 +1356,18 @@ setup_partitions
 if [[ "${ZFS_OS_INSTALLATION_SCRIPT:-}" == "" ]]; then
   # Includes the O/S extra configuration, if necessary (network, root pwd, etc.)
   distro_dependent_invoke "install_operating_system"
+
+  create_pools
+  create_swap_volume
+  sync_os_temp_installation_dir_to_rpool
+  remove_temp_partition_and_expand_rpool
 else
+  create_pools
+  create_swap_volume
+  remove_temp_partition_and_expand_rpool
+
   custom_install_operating_system
 fi
-
-create_pools
-create_swap_volume
-sync_os_temp_installation_dir_to_rpool
-remove_temp_partition_and_expand_rpool
 
 prepare_jail
 distro_dependent_invoke "install_jail_zfs_packages"

--- a/os_install_scripts/from_target_image-guest.sh
+++ b/os_install_scripts/from_target_image-guest.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+c_fifo_filename="/tmp/target_image.fifo"
+c_root_pool_mount=/mnt
+
+echo "Restoring the target image..."
+
+# shellcheck disable=SC2002 # xz doesn't accept as input a fifo, and reverting the commands orde
+# is ugly.
+cat "$c_fifo_filename" | xz -d | tar xv -C "$c_root_pool_mount"
+
+echo

--- a/os_install_scripts/from_target_image-host.sh
+++ b/os_install_scripts/from_target_image-host.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Don't use spaces in the filenames; avoids ugly quoting.
+#
+c_fifo_filename="/tmp/target_image.fifo"
+c_os_install_script="$(dirname "$0")/from_target_image-guest.sh"
+c_zfs_installer_script="$(dirname "${0%/*}")/install-zfs.sh"
+
+if [[ $# -ne 3 ]] || [[ ! -x "$(command -v sshpass)" ]]; then
+  echo "Usage: $(basename "$0") <compressed_image> <host> <password>
+
+Perform a ZFS installation via custom script \`$(basename "$c_os_install_script")\`, using the provided O/S image.
+
+The image must be an XZ-tarball of the target mountpoint (typically, \`/target\`), as it is immediately after the installer (S)Ubiquity has finished.
+The files must be relative to the target mountpoint.
+
+Requirements:
+
+- the \`sshpass\` tool on the host (for convenience);
+- the SSH server on the guest, with allowed password authentication;
+- the SSH client configured on the host.
+" 
+  echo
+  exit 1
+fi
+
+v_image=$1
+v_host=$2
+export SSHPASS=$3
+
+# Initiate the image copy in the background, but block until it's picked up.
+#
+sshpass -e ssh "$v_host" "rm -f $c_fifo_filename && mkfifo $c_fifo_filename"
+sshpass -e scp -q "$v_image" "$v_host":"$c_fifo_filename" &
+
+sshpass -e scp "$c_os_install_script" "$c_zfs_installer_script" "$v_host":
+
+sshpass -e ssh -t "$v_host" "sudo ZFS_OS_INSTALLATION_SCRIPT=./$(basename "$c_os_install_script") ./$(basename "$c_zfs_installer_script")"


### PR DESCRIPTION
In case of custom OS installations, the pools are now prepared before. There are two reasons for this:

1. there is no need to run them after, since we're not subject to Ubiquity's mess-ups;
2. custom installation scripts have the flexibility to install directly to a pool, as they're not subject to Ubiquity's limitations.

A sample pair of scripts is provided, which allows installing from a compressed image, for a speed installation process.

Closes #117. Closes #118.