### PR TITLE
Improve disks wiping, by using the zpool functionality

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck disable=SC2015,SC2016,SC2034
+# shellcheck disable=SC2015,SC2016
 
 # Shellcheck issue descriptions:
 #

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -714,6 +714,12 @@ function setup_partitions {
   fi
 
   for selected_disk in "${v_selected_disks[@]}"; do
+    # wipefs doesn't fully wipe ZFS labels.
+    #
+    find "$(dirname "$selected_disk")" -name "$(basename "$selected_disk")-part*" -exec bash -c '
+      zpool labelclear -f "$1" 2> /dev/null || true
+    ' _ {} \;
+
     # More thorough than `sgdisk --zap-all`.
     #
     wipefs --all "$selected_disk"


### PR DESCRIPTION
`wipefs` doesn't fully wipe ZFS labels, so we use the zpool functionality.

Also, removed a leftover Shellcheck directive.