### PR TITLE
Ctrl+Shift+F1 should be Ctrl+Alt+F1

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -898,7 +898,7 @@ function install_operating_system_UbuntuServer {
 
   local dialog_message='You'\''ll now need to run the Ubuntu Server installer (Subiquity).
 
-Switch back to the original terminal (Ctrl+Shift+F1), then proceed with the configuration as usual.
+Switch back to the original terminal (Ctrl+Alt+F1), then proceed with the configuration as usual.
 
 When the update option is presented, choose to update Subiquity to the latest version.
 


### PR DESCRIPTION
Just a small typo in the description: switching back to the original terminal is done with Ctrl+Alt+F1, not Ctrl+Shift+F1.