### PR TITLE
Increase boot pool default size

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -560,7 +560,7 @@ Supported formats: '512M', '3G'" 30 100 $c_default_boot_partition_size 3>&1 1>&2
     done
   fi
 
-  print_variables v_swap_size
+  print_variables v_boot_partition_size
 }
 
 function ask_swap_size {

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -47,7 +47,7 @@ v_suitable_disks=()          # (/dev/by-id/disk_id, ...); scope: find_suitable_d
 # specific to it.
 
 c_efi_system_partition_size=512M
-c_default_boot_partition_size=768M # while 512M are enough for a few kernels, the Ubuntu updater complains after a couple
+c_default_boot_partition_size=2048M
 c_default_bpool_tweaks="-o ashift=12"
 c_default_rpool_tweaks="-o ashift=12 -O acltype=posixacl -O compression=lz4 -O dnodesize=auto -O relatime=on -O xattr=sa -O normalization=formD"
 c_zfs_mount_dir=/mnt


### PR DESCRIPTION
Size increases quite quickly, so for advanced users, a more generous size (2048M) is appropriate.