### PR TITLE
Add Linuxmint 20.1 as supported version

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -52,7 +52,7 @@ c_default_bpool_tweaks="-o ashift=12"
 c_default_rpool_tweaks="-o ashift=12 -O acltype=posixacl -O compression=lz4 -O dnodesize=auto -O relatime=on -O xattr=sa -O normalization=formD"
 c_zfs_mount_dir=/mnt
 c_installed_os_data_mount_dir=/target
-declare -A c_supported_linux_distributions=([Debian]=10 [Ubuntu]="18.04 20.04" [UbuntuServer]="18.04 20.04" [LinuxMint]="19.1 19.2 19.3" [Linuxmint]="20" [elementary]=5.1)
+declare -A c_supported_linux_distributions=([Debian]=10 [Ubuntu]="18.04 20.04" [UbuntuServer]="18.04 20.04" [LinuxMint]="19.1 19.2 19.3" [Linuxmint]="20 20.1" [elementary]=5.1)
 c_temporary_volume_size=12  # gigabytes; large enough - Debian, for example, takes ~8 GiB.
 c_passphrase_named_pipe=$(dirname "$(mktemp)")/zfs-installer.pp.fifo
 c_passphrase_named_pipe_2=$(dirname "$(mktemp)")/zfs-installer.pp.2.fifo


### PR DESCRIPTION
This script worked flawlessly for me using for installing the current LinuxMint 20.1 (XFCE, in my case) on my Lenovo x260 laptop.

Not sure whether this is needed or if the Mint installer [Experimantal ZFS on Root feature](https://forums.linuxmint.com/viewtopic.php?p=1840175) should be used? Anyway, so far no complaints from my side.