### PR TITLE
Add compatibility with the standard Ubuntu Desktop

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -531,22 +531,33 @@ export ZFS_FREE_TAIL_SPACE=12
   trap _exit_hook EXIT
 }
 
-function update_apt_index {
-  apt update
+function prepare_standard_repositories {
+  # Make sure it's enabled. Ubuntu MATE has it, while the standard Ubuntu doesn't.
+  # The program exits with success if the repository is already enabled.
+  #
+  add-apt-repository --yes --no-update universe
 }
 
 # Mint 20 has the CDROM repository enabled, but apt fails when updating due to it (or possibly due
 # to it being incorrectly setup).
 #
-function update_apt_index_Linuxmint {
+function prepare_standard_repositories_Linuxmint {
   perl -i -pe 's/^(deb cdrom)/# $1/' /etc/apt/sources.list
 
-  invoke "update_apt_index"
+  # The universe repository may be already enabled, but it's more solid to ensure it.
+  #
+  invoke "prepare_standard_repositories"
 }
 
-# REQUIREMENT: it must be ensured that, for any distro, `apt update` is invoked at this step, as
-# subsequent steps rely on it.
-#
+function prepare_standard_repositories_Debian {
+  # Debian doesn't require universe (for dialog).
+  :
+}
+
+function update_apt_index {
+  apt update
+}
+
 # There are three parameters:
 #
 # 1. the tools are preinstalled (ie. Ubuntu Desktop based);
@@ -1514,6 +1525,7 @@ invoke "save_disks_log"
 invoke "find_suitable_disks"
 invoke "register_exit_hook"
 invoke "create_passphrase_named_pipe"
+invoke "prepare_standard_repositories"
 invoke "update_apt_index"
 invoke "set_zfs_ppa_requirement"
 invoke "install_dialog_package"

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -567,7 +567,7 @@ function update_apt_index {
 # Fortunately, with Debian-specific logic isolated, we need conditionals based only on #2 - see
 # install_host_packages() and install_host_packages_UbuntuServer().
 #
-function set_zfs_ppa_requirement {
+function set_use_zfs_ppa {
   local zfs_package_version
   zfs_package_version=$(apt show zfsutils-linux 2> /dev/null | perl -ne 'print /^Version: (\d+\.\d+)/')
 
@@ -578,7 +578,7 @@ function set_zfs_ppa_requirement {
   fi
 }
 
-function set_zfs_ppa_requirement_Debian {
+function set_use_zfs_ppa_Debian {
   # Only update apt; in this case, ZFS packages are handled in a specific way.
   :
 }
@@ -1527,7 +1527,7 @@ invoke "register_exit_hook"
 invoke "create_passphrase_named_pipe"
 invoke "prepare_standard_repositories"
 invoke "update_apt_index"
-invoke "set_zfs_ppa_requirement"
+invoke "set_use_zfs_ppa"
 invoke "install_dialog_package"
 
 invoke "select_disks"

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -476,46 +476,6 @@ If you think this is a bug, please open an issue on https://github.com/saveriomi
   print_variables v_suitable_disks
 }
 
-# REQUIREMENT: it must be ensured that, for any distro, `apt update` is invoked at this step, as
-# subsequent steps rely on it.
-#
-# There are three parameters:
-#
-# 1. the tools are preinstalled (ie. Ubuntu Desktop based);
-# 2. the default repository supports ZFS 0.8 (ie. Ubuntu 20.04+ based);
-# 3. the distro provides the precompiled ZFS module (i.e. Ubuntu based, not Debian)
-#
-# Fortunately, with Debian-specific logic isolated, we need conditionals based only on #2 - see
-# install_host_packages() and install_host_packages_UbuntuServer().
-#
-function set_zfs_ppa_requirement {
-  apt update
-
-  local zfs_package_version
-  zfs_package_version=$(apt show zfsutils-linux 2> /dev/null | perl -ne 'print /^Version: (\d+\.\d+)/')
-
-  # Test returns true if $zfs_package_version is blank.
-  #
-  if [[ ${ZFS_USE_PPA:-} == "1" ]] || dpkg --compare-versions "$zfs_package_version" lt 0.8; then
-    v_use_ppa=1
-  fi
-}
-
-function set_zfs_ppa_requirement_Debian {
-  # Only update apt; in this case, ZFS packages are handled in a specific way.
-
-  apt update
-}
-
-# Mint 20 has the CDROM repository enabled, but apt fails when updating due to it (or possibly due
-# to it being incorrectly setup).
-#
-function set_zfs_ppa_requirement_Linuxmint {
-  perl -i -pe 's/^(deb cdrom)/# $1/' /etc/apt/sources.list
-
-  invoke "set_zfs_ppa_requirement"
-}
-
 # By using a FIFO, we avoid having to hide statements like `echo $v_passphrase | zpoool create ...`
 # from the logs.
 #
@@ -569,6 +529,46 @@ export ZFS_FREE_TAIL_SPACE=12
     set -x
   }
   trap _exit_hook EXIT
+}
+
+# REQUIREMENT: it must be ensured that, for any distro, `apt update` is invoked at this step, as
+# subsequent steps rely on it.
+#
+# There are three parameters:
+#
+# 1. the tools are preinstalled (ie. Ubuntu Desktop based);
+# 2. the default repository supports ZFS 0.8 (ie. Ubuntu 20.04+ based);
+# 3. the distro provides the precompiled ZFS module (i.e. Ubuntu based, not Debian)
+#
+# Fortunately, with Debian-specific logic isolated, we need conditionals based only on #2 - see
+# install_host_packages() and install_host_packages_UbuntuServer().
+#
+function set_zfs_ppa_requirement {
+  apt update
+
+  local zfs_package_version
+  zfs_package_version=$(apt show zfsutils-linux 2> /dev/null | perl -ne 'print /^Version: (\d+\.\d+)/')
+
+  # Test returns true if $zfs_package_version is blank.
+  #
+  if [[ ${ZFS_USE_PPA:-} == "1" ]] || dpkg --compare-versions "$zfs_package_version" lt 0.8; then
+    v_use_ppa=1
+  fi
+}
+
+function set_zfs_ppa_requirement_Debian {
+  # Only update apt; in this case, ZFS packages are handled in a specific way.
+
+  apt update
+}
+
+# Mint 20 has the CDROM repository enabled, but apt fails when updating due to it (or possibly due
+# to it being incorrectly setup).
+#
+function set_zfs_ppa_requirement_Linuxmint {
+  perl -i -pe 's/^(deb cdrom)/# $1/' /etc/apt/sources.list
+
+  invoke "set_zfs_ppa_requirement"
 }
 
 # Whiptail's lack of multiline editing is quite painful.
@@ -1511,9 +1511,9 @@ invoke "display_intro_banner"
 invoke "check_system_memory"
 invoke "save_disks_log"
 invoke "find_suitable_disks"
-invoke "set_zfs_ppa_requirement"
 invoke "register_exit_hook"
 invoke "create_passphrase_named_pipe"
+invoke "set_zfs_ppa_requirement"
 invoke "install_dialog_package"
 
 invoke "select_disks"

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -531,6 +531,19 @@ export ZFS_FREE_TAIL_SPACE=12
   trap _exit_hook EXIT
 }
 
+function update_apt_index {
+  apt update
+}
+
+# Mint 20 has the CDROM repository enabled, but apt fails when updating due to it (or possibly due
+# to it being incorrectly setup).
+#
+function update_apt_index_Linuxmint {
+  perl -i -pe 's/^(deb cdrom)/# $1/' /etc/apt/sources.list
+
+  invoke "update_apt_index"
+}
+
 # REQUIREMENT: it must be ensured that, for any distro, `apt update` is invoked at this step, as
 # subsequent steps rely on it.
 #
@@ -544,8 +557,6 @@ export ZFS_FREE_TAIL_SPACE=12
 # install_host_packages() and install_host_packages_UbuntuServer().
 #
 function set_zfs_ppa_requirement {
-  apt update
-
   local zfs_package_version
   zfs_package_version=$(apt show zfsutils-linux 2> /dev/null | perl -ne 'print /^Version: (\d+\.\d+)/')
 
@@ -558,17 +569,7 @@ function set_zfs_ppa_requirement {
 
 function set_zfs_ppa_requirement_Debian {
   # Only update apt; in this case, ZFS packages are handled in a specific way.
-
-  apt update
-}
-
-# Mint 20 has the CDROM repository enabled, but apt fails when updating due to it (or possibly due
-# to it being incorrectly setup).
-#
-function set_zfs_ppa_requirement_Linuxmint {
-  perl -i -pe 's/^(deb cdrom)/# $1/' /etc/apt/sources.list
-
-  invoke "set_zfs_ppa_requirement"
+  :
 }
 
 # Whiptail's lack of multiline editing is quite painful.
@@ -1513,6 +1514,7 @@ invoke "save_disks_log"
 invoke "find_suitable_disks"
 invoke "register_exit_hook"
 invoke "create_passphrase_named_pipe"
+invoke "update_apt_index"
 invoke "set_zfs_ppa_requirement"
 invoke "install_dialog_package"
 


### PR DESCRIPTION
The universe repository is not enabled by default.

Also done minor refactoring, most notably, split the apt update, which makes the step evident (before, it was hidden).