### PR TITLE
Ubuntu Server: fix the udev* systemd units (re)start

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -920,7 +920,7 @@ function install_host_zfs_packages_UbuntuServer {
     umount /lib/modules
     rm -r /lib/modules
     ln -s /tmp/modules /lib
-    systemctl start 'systemd-udevd*'
+    systemctl start --all 'systemd-udevd*'
 
     # Additionally, the linux packages for the running kernel are not installed, at least when
     # the standard installation is performed. Didn't test on the HWE option; if it's not required,


### PR DESCRIPTION
Using a glob requires `--all` in order to work as intended, otherwise, it doesn't start units that are not loaded already.

Closes #200.