### PR TITLE
Generalize fix filesystem mount ordering

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -1450,10 +1450,15 @@ function fix_filesystem_mount_ordering {
   local success=
 
   if [[ ! -s $c_zfs_mount_dir/etc/zfs/zfs-list.cache/$c_bpool_name || ! -s $c_zfs_mount_dir/etc/zfs/zfs-list.cache/$v_rpool_name ]]; then
+    local zfs_root_fs zfs_boot_fs
+
+    zfs_root_fs=$(chroot_execute 'zfs list /     | awk "NR==2 {print \$1}"')
+    zfs_boot_fs=$(chroot_execute 'zfs list /boot | awk "NR==2 {print \$1}"')
+
     # For the rpool only, it takes around half second on a test VM.
     #
-    chroot_execute "zfs set canmount=on $c_bpool_name"
-    chroot_execute "zfs set canmount=on $v_rpool_name/ROOT"
+    chroot_execute "zfs set canmount=on $zfs_boot_fs"
+    chroot_execute "zfs set canmount=on $zfs_root_fs"
 
     SECONDS=0
 


### PR DESCRIPTION
Previously, it wasn't taken into account that the root FS may not be `$v_rpool_name/ROOT`.