### PR TITLE
Fix EFI partitions mount

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -1385,7 +1385,7 @@ function prepare_fstab {
       local mountpoint=/boot/efi$((i + 1))
     fi
 
-    chroot_execute "echo /dev/disk/by-uuid/$(blkid -s UUID -o value "${v_selected_disks[i]}"-part1) $mountpoint vfat nofail,x-systemd.device-timeout=10 0 0 >> /etc/fstab"
+    chroot_execute "echo /dev/disk/by-uuid/$(blkid -s UUID -o value "${v_selected_disks[i]}"-part1) $mountpoint vfat nofail,x-systemd.requires=zfs-mount.service,x-systemd.device-timeout=10 0 0 >> /etc/fstab"
   done
 
   if (( v_swap_size > 0 )); then

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -1385,7 +1385,7 @@ function prepare_fstab {
       local mountpoint=/boot/efi$((i + 1))
     fi
 
-    chroot_execute "echo /dev/disk/by-uuid/$(blkid -s UUID -o value "${v_selected_disks[i]}"-part1) $mountpoint vfat defaults 0 0 >> /etc/fstab"
+    chroot_execute "echo /dev/disk/by-uuid/$(blkid -s UUID -o value "${v_selected_disks[i]}"-part1) $mountpoint vfat nofail 0 0 >> /etc/fstab"
   done
 
   if (( v_swap_size > 0 )); then

--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -1385,7 +1385,7 @@ function prepare_fstab {
       local mountpoint=/boot/efi$((i + 1))
     fi
 
-    chroot_execute "echo /dev/disk/by-uuid/$(blkid -s UUID -o value "${v_selected_disks[i]}"-part1) $mountpoint vfat nofail 0 0 >> /etc/fstab"
+    chroot_execute "echo /dev/disk/by-uuid/$(blkid -s UUID -o value "${v_selected_disks[i]}"-part1) $mountpoint vfat nofail,x-systemd.device-timeout=10 0 0 >> /etc/fstab"
   done
 
   if (( v_swap_size > 0 )); then


### PR DESCRIPTION
Likely due to the current procedure not still being fully implemented, the EFI partition mounts require handling in order to avoid race conditions during boot.