### PR TITLE
Fix build (annoying shellcheck warning)

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-# Shellcheck issue descriptions:
-#
-# - SC2015: <condition> && <operation> || true
-# - SC2016: annoying warning about using single quoted strings with characters used for interpolation
+# shellcheck disable=SC2016 # single quoted strings with characters used for interpolation
 
 set -o errexit
 set -o pipefail


### PR DESCRIPTION
It wasn't clear why the builder was failing, until I've realized I had a .shellcheckrc :grimacing:.