### PR TITLE
Improve the description (device reference) in the Subiquity launch dialog

### DIFF
--- a/install-zfs.sh
+++ b/install-zfs.sh
@@ -1099,7 +1099,7 @@ When the update option is presented, choose to update Subiquity to the latest ve
 At the partitioning stage:
 
 - select `Custom storage layout` -> `Done`
-- select `'"$v_temp_volume_device"'` -> `Edit`
+- select `'"${v_selected_disks[0]}"'/partition 4` -> `Edit`
   - set `Format:` to `ext4` (mountpoint will be automatically selected)
   - click `Save`
 - click `Done` -> `Continue` (ignore warning)


### PR DESCRIPTION
Replace `/dev/sda4` with the disk id, which Subiquity displays.

It's still not perfect, because the prefixes (like `scsi-0ATA_`) that are not displayed in Subiquity, but it should be clear enough.

Closes #224.